### PR TITLE
Define linewise maps after checking hasmapto

### DIFF
--- a/plugin/sad.vim
+++ b/plugin/sad.vim
@@ -22,9 +22,6 @@ xnoremap <silent> <Plug>(sad-change-backward) :<C-u>call sad#search_and_replace_
 nnoremap <expr><silent> <Plug>(sad-change-forward) ':<C-u>set opfunc=sad#search_and_replace_forward<CR>"'.v:register.'g@'
 nnoremap <expr><silent> <Plug>(sad-change-backward) ':<C-u>set opfunc=sad#search_and_replace_backward<CR>"'.v:register.'g@'
 
-nmap <expr> <Plug>(sad-change-forward-linewise) '0"'.v:register.'<Plug>(sad-change-forward)'.v:count1.'g_'
-nmap <expr> <Plug>(sad-change-backward-linewise) '0"'.v:register.'<Plug>(sad-change-backward)'.v:count1.'g_'
-
 if !hasmapto('<Plug>(sad-search-forward)') || !hasmapto('<Plug>(sad-search-backward)')
     xmap * <Plug>(sad-search-forward)
     xmap # <Plug>(sad-search-backward)
@@ -36,7 +33,12 @@ if !hasmapto('<Plug>(sad-change-forward)') || !hasmapto('<Plug>(sad-change-backw
 
     nmap s <Plug>(sad-change-forward)
     nmap S <Plug>(sad-change-backward)
+endif
 
+nmap <expr> <Plug>(sad-change-forward-linewise) '0"'.v:register.'<Plug>(sad-change-forward)'.v:count1.'g_'
+nmap <expr> <Plug>(sad-change-backward-linewise) '0"'.v:register.'<Plug>(sad-change-backward)'.v:count1.'g_'
+
+if !hasmapto('<Plug>(sad-change-forward-linewise)') || !hasmapto('<Plug>(sad-change-backward-linewise)')
     nmap ss <Plug>(sad-change-forward-linewise)
     nmap SS <Plug>(sad-change-backward-linewise)
 endif


### PR DESCRIPTION
The linewise mappings define a mapping with `<Plug>(sad-change-*)` in its `rhs`, causing the following `hasmapto('<Plug>(sad-change-*)')` checks to return `1`, even though I haven't set any myself, so the default keybindings aren't applied.

I'm using NeoVim 0.2.0 and the master branch of `sad.vim`